### PR TITLE
ci: Testing: make a trivial documentation-related edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,6 @@ a fund established by NLnet with financial support from the European Commission'
 
 <div align="center">
 
-<br />
 <a href="https://www.digitalpublicgoods.net/r/open-food-facts" target="_blank" rel="noopener noreferrer"><img src="https://github.com/DPGAlliance/dpg-resources/blob/main/docs/assets/dpg-badge.png?raw=true" width="100" alt="Digital Public Goods Badge"></a>
 
 </div>

--- a/README.md
+++ b/README.md
@@ -157,3 +157,4 @@ a fund established by NLnet with financial support from the European Commission'
 <a href="https://www.digitalpublicgoods.net/r/open-food-facts" target="_blank" rel="noopener noreferrer"><img src="https://github.com/DPGAlliance/dpg-resources/blob/main/docs/assets/dpg-badge.png?raw=true" width="100" alt="Digital Public Goods Badge"></a>
 
 </div>
+

--- a/cgi/version.pl
+++ b/cgi/version.pl
@@ -31,4 +31,3 @@ use CGI qw/:cgi :form escapeHTML/;
 print header(-type => 'text/html', -charset => 'utf-8') . "Version: $version";
 
 exit(0);
-

--- a/cgi/version.pl
+++ b/cgi/version.pl
@@ -31,3 +31,5 @@ use CGI qw/:cgi :form escapeHTML/;
 print header(-type => 'text/html', -charset => 'utf-8') . "Version: $version";
 
 exit(0);
+
+


### PR DESCRIPTION
Currently, the following behaviours are configured for GitHub Actions pull request checks in this repository:

 * Documentation-related commits (Markdown files, `CODEOWNERS`, the pull request template, and `.editorconfig` files) in pull requests succeed.
 * Non-documetation-related commits in pull requests fail.

These are configured using the [GitHub Actions `paths` and `paths-ignore`](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore) feature.

Each documentation-related job (e.g. `Check perl`) has a duplicate non-documentation job with exactly the same name.

This implements a GitHub Actions required-statuses workaround described at: https://github.com/orgs/community/discussions/49124#discussioncomment-5209069

The purpose of this pull request is to find out whether that workaround remains valid.  If so, it may provide a simpler solution than using a custom/third-party GitHub Actions action.

Questions:

  * What happens when a pull request contains _both_ documentation and non-documentation modifications?
  * If we were to use this mechanism, is there a way that we could ensure that the inverted and non-inverted path configurations stay in-sync?