### PR TITLE
ci: Testing: GitHub Actions / paths-filter action testing with negated blob regexes

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -42,4 +42,3 @@ See also [targets to run tests](../docs/dev/how-to-write-and-run-tests.md#runnin
 `export MSYS_NO_PATHCONV=1
 docker compose run --rm --no-deps -u root backend chown www-data:www-data -R /opt/product-opener/`
 then run again `make lint` and you should be good to go
-


### PR DESCRIPTION
This is a follow-up to #3, a simpler/easier test that completed successfully.

In this one, we're trying to use negated blob matching (`!`) with `dorny/paths-filter` to ignore certain files from being modified.

The end goal is for my modification to `docker/README.md` to be ignored, and the [`pull_request.yml` configuration here](https://github.com/openculinary/openfoodfacts-server/blob/9a2abb66a4e0cff241ba0a3278763e08004d0128/.github/workflows/pull_request.yml#L54-L56) attempts to configure that.  That means that we want the resulting GitHub Actions CI run to skip the `Warning: docker configuration modified` job.

https://github.com/openculinary/openfoodfacts-server/blob/9a2abb66a4e0cff241ba0a3278763e08004d0128/.github/workflows/pull_request.yml#L54-L56

But what I think will happen is that the `!` glob does not work as expected.  There are some reports about this upstream -- and a `predicate-quantifier` [config setting](https://github.com/dorny/paths-filter/issues/184#issuecomment-2316064616) that may help: https://github.com/dorny/paths-filter/issues/184