### PR TITLE
ci: Testing: make a trivial docker config documentation-related edit

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -42,4 +42,3 @@ See also [targets to run tests](../docs/dev/how-to-write-and-run-tests.md#runnin
 `export MSYS_NO_PATHCONV=1
 docker compose run --rm --no-deps -u root backend chown www-data:www-data -R /opt/product-opener/`
 then run again `make lint` and you should be good to go
-


### PR DESCRIPTION
Duplicates #4, but with the `paths-filter` [`predicate-quantifier` setting](https://github.com/dorny/paths-filter/blob/de90cc6fb38fc0963ad72b210f1f284cd68cea36/README.md?plain=1#L157-L171) configured this time, and upgraded to `v3` of the action.