### PR TITLE
ci: pull_requests.yml: ensure a checkout exists

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,6 +27,7 @@ jobs:
     outputs:
       code_modified: ${{ steps.filter.outputs.code }}
     steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:


### PR DESCRIPTION
The `push` event in GitHub Actions does not implicitly create a clone of the repository, unlike the `pull_request` event.

Since the `dorny/paths-filter` action we use to handle both event types does require a checkout, this commit adds an explicit checkout step to the job.

Refs:
 - https://github.com/dorny/paths-filter/blob/de90cc6fb38fc0963ad72b210f1f284cd68cea36/README.md?plain=1#L29